### PR TITLE
[Feature flags SDK] Fix URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You will need your signing key, which you can copy from the integration settings
 
 To send an event to your Panobi workspace, make an HTTP POST request with a JSON body to the following endpoint:
 
-https://panobi.com/integrations/flags-sdk/events
+https://app.panobi.com/integrations/flags-sdk/events
 
 The body of the request should be JSON encoded. The complete format can be found in the provided [OpenAPI specification](openapi.yaml). For example, the following payload would mark a single flag named `Beta Feature XYZ` as live:
 
@@ -53,6 +53,12 @@ The little shell script below demonstrates the complete process, including how t
 # it. The first argument to this script is the name of that file.
 input=$(<"$1")
 
+# Check that we have a signing key
+if [[ -z "$FEATURE_FLAG_SDK_SIGNING_KEY" ]]; then
+	echo "Did you forget to set \$FEATURE_FLAG_SDK_SIGNING_KEY?"
+	exit 1
+fi
+
 # Split the signing key into its component parts.
 arr=(${FEATURE_FLAG_SDK_SIGNING_KEY//-/ })
 wid=${arr[0]}    # Workspace ID
@@ -66,7 +72,7 @@ ts=$(date +%s)000
 # Hash the timestamp and the request body using the secret part of the signing
 # key.
 msg="v0:${ts}:${input}"
-sig=$(echo -n "${msg}" | openssl dgst -sha256 -hmac "${secret}")
+sig=$(echo -n "${msg}" | openssl dgst -r -sha256 -hmac "${secret}" | awk '{print $1}')
 
 # Post the headers and the request to Panobi using good ol' curl.
 curl -v \
@@ -75,7 +81,7 @@ curl -v \
     -H "X-Panobi-Request-Timestamp: ""${ts}" \
     -H "Content-Type: application/json" \
     -d "${input}" \
-    https://panobi.com/integrations/flags-sdk/events/"${wid}"/"${eid}"
+    https://app.panobi.com/integrations/flags-sdk/events/"${wid}"/"${eid}"
 ```
 
 Once the event has been successfully sent, the flag is available for use in your Panobi workspace. You should be able to select it from a drop-down menu in the editor panel for any Panobi Project. Once selected, the state of the flag will be reflected in the Panobi Project. For example, if the flag is enabled, then the Panobi Project will be marked as Live, and moved into the appropriate column inside Panobi. If the flag is then disabled via a subsequent event, the Panobi Project will be marked as Complete.


### PR DESCRIPTION
## Description

We need to use the `app` subdomain. Also includes a fix to the signature calculation, which I forgot to commit yesterday 🤦 and a handy check for the signing key.

**NOTE** I will make this same fix to the Metrics SDK.

## References

## Testing

```
...
< HTTP/1.1 200 OK
< Content-Type: application/json
< Vary: Authorization
< Date: Wed, 06 Mar 2024 15:37:04 GMT
< Content-Length: 5

{"message":{"message":"request","properties":{"member_id":"","request_id":"965cf3f5-e5b8-4428-a63f-abc27ba455cc","workspace_id":"T8..."}},"severity":"INFO","httpRequest":{"requestMethod":"POST","requestUrl":"/integrations/flags-sdk/events/T8.../HV...","status":200,"userAgent":"curl/8.1.2","latency":"0.370631250s","protocol":"HTTP/1.1"},"timestamp":"seconds:1709739437  nanos:694291000"}
```